### PR TITLE
removed automatic pyscf installation, which has some problems

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,9 @@ This plugin library allows the electronic structure package `PySCF <http://githu
 Installation
 ------------
 
-To install the latest versions of OpenFermion, PySCF and OpenFermion-PySCF (in development mode):
+To start using OpenFermion-PySCF, first install `PySCF
+<http://github.com/sunqm/pyscf>`__.
+Then, to install the latest versions of OpenFermion and OpenFermion-PySCF (in development mode):
 
 .. code-block:: bash
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 openfermion>=0.1a3
-pyscf


### PR DESCRIPTION
Fixes https://github.com/quantumlib/OpenFermion-PySCF/issues/14
by removing explicit requirement.