### PR TITLE
Bump version to 0.4

### DIFF
--- a/openfermionpyscf/_version.py
+++ b/openfermionpyscf/_version.py
@@ -11,4 +11,4 @@
 #   limitations under the License.
 
 """Define version number here and read it from setup.py automatically"""
-__version__ = "0.3"
+__version__ = "0.4"


### PR DESCRIPTION
Necessary to sync the library with PySCF (see #41 ).