### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-openfermion>=0.5
+openfermion>=1.0
 pyscf
 pytest


### PR DESCRIPTION
openfermionpyscf now requires `openfermion>1.0`, where some interfaces have changed from the previous versions.