### PR TITLE
Implementation of Hamiltonian using natural orbitals

### DIFF
--- a/openfermionpyscf/_run_pyscf.py
+++ b/openfermionpyscf/_run_pyscf.py
@@ -145,6 +145,7 @@ def compute_integrals(pyscf_molecule, orb_coeff):
 
 def run_pyscf(molecule,
               nat_orb=False,
+              guess_mix=False,
               run_scf=True,
               run_mp2=False,
               run_cisd=False,
@@ -179,7 +180,10 @@ def run_pyscf(molecule,
         pyscf_scf = scf.UHF(pyscf_molecule)
         pyscf_scf.conv_tol = 1e-6
         pyscf_scf.verbose = 0
-        pyscf_scf.run(mixed_orbitals_density_matrix(pyscf_molecule))
+        if guess_mix:
+            pyscf_scf.run(mixed_orbitals_density_matrix(pyscf_molecule))
+        else:
+            pyscf_scf.run()
 
         # Calculation of natural orbitals
         dm_uhf = pyscf_scf.make_rdm1(pyscf_scf.mo_coeff, pyscf_scf.mo_occ)


### PR DESCRIPTION
Dear developers, 

I implemented some additions to the code that I think could be useful. 
I added the option to construct the Hamiltonian using the natural orbitals obtained from an unrestricted Hartree-Fock calculation. In this implementation I replace the canonical orbitals by the natural orbitals if this option is requested. I have also included the option to use a HOMO-LUMO mixed guess for the UHF as written in the PYSCF example 56 (https://github.com/pyscf/pyscf.github.io/blob/master/examples/scf/56-h2_symm_breaking.py).

Feel free to do the modifications to the code that you consider.