### PR TITLE
Unpin versions in pip-list

### DIFF
--- a/dev_tools/pip-list
+++ b/dev_tools/pip-list
@@ -1,3 +1,3 @@
-pytest~=6.2.1
-pyscf~=1.7.5.1
-openfermion~=1.0.0
+pytest
+pyscf
+openfermion


### PR DESCRIPTION
The requested versions of the packages are so old that I can't get them working on the versions of OSes and Python that are currently available on GitHub runners.